### PR TITLE
ci: add default project for issues

### DIFF
--- a/.github/workflows/project_automations.yml
+++ b/.github/workflows/project_automations.yml
@@ -1,0 +1,23 @@
+name: Project automations
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  issue_opened:
+    name: issue_opened
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    steps:
+      - name: 'Move issue to Todo'
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        with:
+          user: the-convocation
+          project_id: 1
+          status_value: "Todo"
+          gh_app_secret_key: ${{ secrets.PROJECT_AUTOMATIONS_GH_APP_SECRET_KEY }}
+          gh_app_ID: ${{ secrets.PROJECT_AUTOMATIONS_GH_APP_ID }}
+          gh_app_installation_ID: ${{ secrets.PROJECT_AUTOMATIONS_GH_APP_INSTALLATION_ID }}
+          resource_node_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
There's no way out of the box to assign issues to a default project. This action will add them by default to our main project board. This could be enhanced in the future to use different project boards and/or add PRs too. This will let us use the project/kanban board as a one-stop-shop for tracking issues.

https://github.com/leonsteinhaeuser/project-beta-automations
