### PR TITLE
chore: always checkout JS/TS files as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,10 @@
 # The above will handle all files NOT found below
 #
 
+# Code
+*.js       text eol=lf
+*.ts       text eol=lf
+
 # Documents
 *.bibtex   text diff=bibtex
 *.doc      diff=astextplain


### PR DESCRIPTION
Our lint settings require files to have LF line endings; this supports that in our .gitattributes.