### PR TITLE
feat(sentry): add optional sentry support

### DIFF
--- a/core/.env.example
+++ b/core/.env.example
@@ -15,6 +15,13 @@ GUILD_ID_WITH_COMMANDS=YourGuildId
 ROLE_WITHOUT_PLAYLIST_PERMISSION=YourRoleId
 
 #
+# Optional: Sentry configuration
+# Setting this value will enable Sentry error reporting.
+# If you are self-hosting Venat, you do not need to set this value.
+#
+#SENTRY_DSN=
+
+#
 # Developer settings - do not touch unless you know what you are doing!
 #
 # Turns on TypeORM schema sync for easy development; you might lose data with this on, so be careful!

--- a/core/package.json
+++ b/core/package.json
@@ -39,5 +39,9 @@
   "packageManager": "yarn@3.2.1",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@sentry/core": "^6.19.7",
+    "@sentry/node": "^6.19.7"
   }
 }

--- a/core/src/app.module.ts
+++ b/core/src/app.module.ts
@@ -5,10 +5,12 @@ import { BotModule } from './bot/bot.module';
 import { DatabaseModule } from './database/database.module';
 import { UsersModule } from './users/users.module';
 import { ModuleLoader } from './module-system/module.loader';
+import { SentryModule } from './sentry/sentry.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
+    SentryModule,
     DatabaseModule,
     UsersModule,
     BotModule,

--- a/core/src/sentry/sentry.filter.ts
+++ b/core/src/sentry/sentry.filter.ts
@@ -1,0 +1,11 @@
+import { BaseExceptionFilter } from '@nestjs/core';
+import { ArgumentsHost, Catch } from '@nestjs/common';
+import * as Sentry from '@sentry/node';
+
+@Catch()
+export class SentryNestExceptionFilter extends BaseExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    Sentry.captureException(exception);
+    super.catch(exception, host);
+  }
+}

--- a/core/src/sentry/sentry.module.ts
+++ b/core/src/sentry/sentry.module.ts
@@ -1,0 +1,31 @@
+import { Logger, Module, OnModuleInit } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/node';
+import { APP_FILTER } from '@nestjs/core';
+import { SentryNestExceptionFilter } from './sentry.filter';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: SentryNestExceptionFilter,
+    },
+  ],
+})
+export class SentryModule implements OnModuleInit {
+  private logger: Logger = new Logger('SentryModule');
+
+  constructor(private config: ConfigService) {}
+
+  onModuleInit(): void {
+    const dsn = this.config.get('SENTRY_DSN');
+    if (!dsn) {
+      this.logger.log('Sentry is disabled (SENTRY_DSN is not set)');
+      return;
+    }
+
+    Sentry.init({ dsn });
+    this.logger.log('Sentry is enabled');
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,6 +1683,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/core@npm:6.19.7, @sentry/core@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/core@npm:6.19.7"
+  dependencies:
+    "@sentry/hub": 6.19.7
+    "@sentry/minimal": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    tslib: ^1.9.3
+  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
+  languageName: node
+  linkType: hard
+
+"@sentry/hub@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/hub@npm:6.19.7"
+  dependencies:
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    tslib: ^1.9.3
+  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
+  languageName: node
+  linkType: hard
+
+"@sentry/minimal@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/minimal@npm:6.19.7"
+  dependencies:
+    "@sentry/hub": 6.19.7
+    "@sentry/types": 6.19.7
+    tslib: ^1.9.3
+  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
+  languageName: node
+  linkType: hard
+
+"@sentry/node@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/node@npm:6.19.7"
+  dependencies:
+    "@sentry/core": 6.19.7
+    "@sentry/hub": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    cookie: ^0.4.1
+    https-proxy-agent: ^5.0.0
+    lru_map: ^0.3.3
+    tslib: ^1.9.3
+  checksum: 2293b0d1d1f9fac3a451eb94f820bc27721c8edddd1f373064666ddd6272f0a4c70dbe58c6c4b3d3ccaf4578aab8f466d71ee69f6f6ff93521bbb02dfe829ce5
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/types@npm:6.19.7"
+  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/utils@npm:6.19.7"
+  dependencies:
+    "@sentry/types": 6.19.7
+    tslib: ^1.9.3
+  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.23.3":
   version: 0.23.5
   resolution: "@sinclair/typebox@npm:0.23.5"
@@ -1725,6 +1793,9 @@ __metadata:
 "@the-convocation/venat-core@workspace:^, @the-convocation/venat-core@workspace:core":
   version: 0.0.0-use.local
   resolution: "@the-convocation/venat-core@workspace:core"
+  dependencies:
+    "@sentry/core": ^6.19.7
+    "@sentry/node": ^6.19.7
   languageName: unknown
   linkType: soft
 
@@ -3695,6 +3766,13 @@ __metadata:
   dependencies:
     safe-buffer: ~5.1.1
   checksum: 985d974a2d33e1a2543ada51c93e1ba2f73eaed608dc39f229afc78f71dcc4c8b7d7c684aa647e3c6a3a204027444d69e53e169ce94e8d1fa8d7dee80c9c8fed
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.4.1":
+  version: 0.4.2
+  resolution: "cookie@npm:0.4.2"
+  checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
   languageName: node
   linkType: hard
 
@@ -6800,6 +6878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru_map@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "lru_map@npm:0.3.3"
+  checksum: ca9dd43c65ed7a4f117c548028101c5b6855e10923ea9d1f635af53ad20c5868ff428c364d454a7b57fe391b89c704982275410c3c5099cca5aeee00d76e169a
+  languageName: node
+  linkType: hard
+
 "macos-release@npm:^2.5.0":
   version: 2.5.0
   resolution: "macos-release@npm:2.5.0"
@@ -9813,7 +9898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd


### PR DESCRIPTION
(nice)

## Describe your changes
Sentry support is optional and enabled only when the SENTRY_DSN environment variable is set. This adds a very barebones app-level exception filter that simply reports the error to Sentry; this call is a no-op if the Sentry API has not been initialised.

## Issue ticket number and link
#63 
